### PR TITLE
Added overview table from aerostack 2 paper

### DIFF
--- a/aerial_autonomy_stacks.md
+++ b/aerial_autonomy_stacks.md
@@ -4,6 +4,42 @@ Based on [this discussion in Discourse]( https://discourse.ros.org/t/more-aerial
 
 > An aerial autonomy robotics stack is a collection of building blocks that enable the development of autonomous aerial vehicles, by providing a modular and scalable architecture for sensing, perception, planning, and control tasks. It allows unmanned aerial vehicles to perform complex missions without human intervention, while accommodating different hardware configurations and simulation environments.
 
+## Comparison
+
+From the paper 
+
+> Fernandez-Cortizas, Miguel, et al. "Aerostack2: A Software Framework for Developing Multi-robot Aerial Systems." arXiv preprint arXiv:2303.18237 (2023).
+  
+the following autonomy stack table was extracted and adapted. 
+
+| Flight stack  | OS/OC  | Modular | Tested in | Middleware | last  update | MF | RO | MA | MP | PO |
+|---------------|--------|---------|-----------|------------|--------------|----|----|----|----|----|
+| Aerostack     | ✓      | ✓      | S,RL,RO   | ROS        | 10/2021      | ✗  | ✓  | ✓ | ✓  | ✗ |
+| Aerostack2    | ✓      | ✓      | S,RL,RO   | ROS 2      | 03/2023      | ✓  | ✓  | ✓ | ✓  | ✓ |
+| AerialCore    | ✓      | ✓      | S,RL,RO   | ROS        | 03/2023      | ✓  | ✓  | ✓ | ✗  | ✓ |
+| Agilicious    | ✓      | ✓      | S,RL      | ROS        | 03/2023      | ✗  | ✓  | ✗ | ✗  | ✗ |
+| KumarRobotics | ✓      | ✗      | S,RL,RO   | ROS        | 12/2022      | ✗  | ✓  | ✗ | ✓  | ✗ |
+| CrazyChoir    | ✓      | ✗      | S,RL      | ROS 2      | 02/2023      | ✗  | ✓  | ✓ | ✗  | ✗ |
+| UAL           | ✓      | ✗      | S,RL,RO   | ROS        | 12/2022      | ✓  | ✗  | ✗ | ✓  | ✗ |
+| XTDrone       | ✓      | ✓      | S         | ROS        | 03/2023      | ✗  | ✓  | ✗ | ✗  | ✗ |
+| RotorS        | ✓      | ✓      | S         | ROS        | 07/2021      | ✗  | ✓  | ✗ | ✗  | ✗ |
+| GAAS          | ✓      | ✓      | S         | ROS        | 10/2021      | ✗  | ✗  | ✗ | ✗  | ✗ |
+
+**Abbrivations**
+* OS/OC: Open source or Open code
+* MF: Multi-frame 
+* RO: Rate output
+* MA: Multi agent
+* MP: Multi platform
+* PO: Plugin oriented 
+* S: Experiments in simulation
+* RL: Experiments in the lab
+* RO: Experiments outside the lab
+
+## Working list autonomy stacks
+
+This is just a list of autonomy stacks with links, such that later we can add them to the overview.
+
 Working list:
 * [Aerostack2](https://aerostack2.github.io/)
 * [Aerostack(1)](https://github.com/cvar-upm/aerostack/wiki)


### PR DESCRIPTION
@miferco97 I've added the overview of the Aerostack paper! 

Eventually, we can add more stack to this but I'll leave that for another time. I've also added the abbreviation Open code next to open source (OS/OC), because I think that is the term that journals use to indicate that researchers have released their code to be openly viewed as part of their paper, which maybe is a bit more inclusive, as the definition open-source is a bit restrictive. What do you think?

Also, could you check if you can do a github review (comments reject or changes required) of this? I'm trying to figure out if that is possible to do for outsiders or if I should start adding all the aerial ros members  to the github organization itself, so this would be a good test for that. 