### PR TITLE
Add Holybro S500v2 bill of materials

### DIFF
--- a/hardware.md
+++ b/hardware.md
@@ -58,5 +58,30 @@ As these are capable of running some form of Linux, these can handle for instanc
 - [NXP NAVQPlus](https://www.nxp.com/design/designs/navqplus-ai-ml-companion-computer-evk-for-mobile-robotics-ros-ground-stations-and-camera-heads:8MPNAVQ)
 - [Qualcomm RB5](https://developer.qualcomm.com/qualcomm-robotics-rb5-kit)
   
-### ESCs Motors batteries
-Still to be added!
+### Reference Bill of Materials
+
+#### Holybro S500v2
+
+The [Holybro S500v2](https://holybro.com/collections/s500/products/s500-v2-development-kit) is a popular, relatively low-cost quadcopter. This is a list of the parts used with details of battery, motors, ESCs, propellers with reference links to guide custom builds.
+
+
+| S.No | Part Name                               | Part category           | Description                                               | Price (USD) | Qty         | Total Cost (USD) | Official/Reference Link                                                                                                                                                              |
+| ---- | --------------------------------------- | ----------------------- | --------------------------------------------------------- | ----------- | ----------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 1    | Holybro S500 frame                      | Frame                   | With landing gear, 385x385mm                              | 42          | 1           | 42               | [https://holybro.com/collections/s500/products/s500-v2-kit?variant=42724497391805](https://holybro.com/collections/s500/products/s500-v2-kit?variant=42724497391805)                 |
+| 2    | Holybro Pixhawk 6C + GPS + Power module | FC + GPS + Power module | PM02 power module, M9N GPS                                | 290         | 1           | 290              | [https://holybro.com/products/pixhawk-6c?variant=43005243785405](https://holybro.com/products/pixhawk-6c?variant=43005243785405)                                                     |
+| 3    | Holybro 2216 920KV CW                   | Motor                   | 19x19 mounting clockwise rotation                         | 20          | 2           | 40               | [https://holybro.com/products/spare-parts-s500-v2-kit?variant=41591094608061](https://holybro.com/products/spare-parts-s500-v2-kit?variant=41591094608061)                           |
+| 4    | Holybro 2216 920KV CCW                  | Motor                   | 19x19 mounting counter-clockwise rotation                 | 20          | 2           | 40               | [https://holybro.com/products/spare-parts-s500-v2-kit?variant=41591094640829](https://holybro.com/products/spare-parts-s500-v2-kit?variant=41591094640829)                           |
+| 5    | BLHeli S 20A ESC                        | ESC                     | Electronic Speed Controller to drive motors               | 14          | 4           | 56               | [https://holybro.com/products/spare-parts-s500-v2-kit?variant=41591094706365](https://holybro.com/products/spare-parts-s500-v2-kit?variant=41591094706365)                           |
+| 6    | 1045 propellers                         | Props                   | 10x4.5" kit of 2 pairs                                    | 12          | 1           | 12               | [https://holybro.com/products/spare-parts-s500-v2-kit?variant=41591094313149](https://holybro.com/products/spare-parts-s500-v2-kit?variant=41591094313149)                           |
+| 7    | Radiomaster R81 receiver                | Radio receiver          | Used for manually flying drone Line of Sight/testing\*    | 18          | 1           | 18               | [https://holybro.com/products/radiomaster-r81-receiver](https://holybro.com/products/radiomaster-r81-receiver)                                                                       |
+| 8    | Holybro SiK telemetry radio v3          | Telemetry link radio    | 500mW, 433MHz variant, pair of transmitter + receiver\*\* | 63          | 1           | 63               | [https://holybro.com/products/sik-telemetry-radio-v3?variant=42801817485501](https://holybro.com/products/sik-telemetry-radio-v3?variant=42801817485501)                             |
+| 9    | Tattu 5200mAh 4S                        | Battery                 | 4S1P XT60 plug 35C                                        | 63          | 1           | 63               | [https://genstattu.com/tattu-5200mah-14-8v-35c-4s1p-lipo-battery-pack-with-xt60-plug.html](https://genstattu.com/tattu-5200mah-14-8v-35c-4s1p-lipo-battery-pack-with-xt60-plug.html) |
+|      |                                         |                         |                                                           |             | Grand Total | 624              |                                                   |             |             |                  |
+
+**Notes**:
+
+\*It can be used with Radiomaster Multiprotocol (4 in 1) or CC2500 based Radio Controller like FrSky Taranis X9D or similar<br>
+\*\*Used for connecting to ground control station, 915MHz variant also available  
+
+**Useful tool for this page**:
+https://tabletomarkdown.com/convert-spreadsheet-to-markdown/


### PR DESCRIPTION
In order to better understand the motors, propellers, ESCs and other components that can be used to build a reference autonomy platform, I've done a parts breakdown of the Holybro S500V2 to enable developers to source their own compatible parts and build such a platform or even gain a better understanding of what goes into making a quadcopter base platform for such use cases. 

 