### PR TITLE
Add middleware libraries and driver ROS packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,5 +15,5 @@ The following list has been compiled during the startup meeting of this workgrou
 * [Hardware, Components, and Dev Kits](hardware.md)
 * [Aerial Vehicle Types](aerial_vehicles.md)
 * Planning in 3D
-
+* [Middleware and Drivers](middleware_and_drivers.md)
 

--- a/aerial_autonomy_stacks.md
+++ b/aerial_autonomy_stacks.md
@@ -57,3 +57,10 @@ Working list:
 * [RotorS](https://github.com/ethz-asl/rotors_simulator)
 * RISE [paper](https://doi.org/10.55417/fr.2023015)
 * [MRS AUV System](https://github.com/ctu-mrs/mrs_uav_system)
+* [Clover](https://github.com/CopterExpress/clover)
+
+## Partial autonomy packages
+
+A list of packages which don't comprise a full stack but do offer value on top of basic flight controller firmware.
+
+* [MAVROS Controllers](https://github.com/Jaeyoung-Lim/mavros_controllers)

--- a/hardware.md
+++ b/hardware.md
@@ -20,6 +20,7 @@ These are platforms that are currently commercially available for anybody to buy
 - [DJI tello](https://store.dji.com/se/shop/tello-series)
 - [NXP HoverGames Kit](https://www.nxp.com/design/designs/nxp-hovergames-drone-kit-including-rddrone-fmuk66-and-peripherals:KIT-HGDRONEK66) official hardware for the yearly [HoverGames Challenge](https://www.hovergames.com)
 - [Duckiedrone by Duckietown](https://get.duckietown.com/products/duckiedrone-dd21)
+- [Clover by Coex](https://coex.tech/clover)
 
 ## Inhouse-developed platforms
 

--- a/middleware_and_drivers.md
+++ b/middleware_and_drivers.md
@@ -1,6 +1,8 @@
+# Middleware and Drivers
+
 The aim for this page is to provide a collection of ROS packages/related libraries which are very useful for aerial ROS projects either to serve as a reference or directly use as a part of a custom software stack. This list aims to address the gap between the flight controller firmware and purely autonomy related packages. 
 
-# Middleware libraries
+## Middleware libraries
 
 Enabling low overhead publish/subscribe on microcontrollers:
 
@@ -8,7 +10,7 @@ Enabling low overhead publish/subscribe on microcontrollers:
 2. [Zenoh](https://github.com/eclipse-zenoh/zenoh-plugin-dds)
 3. [PX4-FastRTPS](https://github.com/eProsima/px4_to_ros) - superceded by Micro-XRCE-DDS (https://docs.px4.io/main/en/middleware/uxrce_dds.html)
 
-# Driver packages for drone platforms
+## Driver packages for drone platforms
 
 ROS packages built atop SDKs from drone vendors to interface to their closed-source flight controller firmwares. Several of these may be for much older ROS1 distros but can have utility in terms of serving as references.
 

--- a/middleware_and_drivers.md
+++ b/middleware_and_drivers.md
@@ -1,0 +1,17 @@
+The aim for this page is to provide a collection of ROS packages/related libraries which are very useful for aerial ROS projects either to serve as a reference or directly use as a part of a custom software stack. This list aims to address the gap between the flight controller firmware and purely autonomy related packages. 
+
+# Middleware libraries
+
+Enabling low overhead publish/subscribe on microcontrollers:
+
+1. [Micro-XRCE-DDS](https://github.com/eProsima/Micro-XRCE-DDS)
+2. [Zenoh](https://github.com/eclipse-zenoh/zenoh-plugin-dds)
+3. [PX4-FastRTPS](https://github.com/eProsima/px4_to_ros) - superceded by Micro-XRCE-DDS (https://docs.px4.io/main/en/middleware/uxrce_dds.html)
+
+# Driver packages for drone platforms
+
+ROS packages built atop SDKs from drone vendors to interface to their closed-source flight controller firmwares. Several of these may be for much older ROS1 distros but can have utility in terms of serving as references.
+
+1. [Parrot ARDrone Autonomy](https://github.com/AutonomyLab/ardrone_autonomy)
+2. [Parrot Bebop Autonomy](https://github.com/AutonomyLab/bebop_autonomy)
+3. [DJI Tello driver](https://github.com/anqixu/tello_driver)


### PR DESCRIPTION
This PR adds a new page for middleware libraries and other ROS packages which have been popular for drones around proprietary platforms.

Additionally, it adds a section for partial autonomy libraries to start a new list for packages which offer some functions like trajectory controllers but not full blown autonomy stacks.

I have also added a new platform I came across, [Clover by Coex](https://coex.tech/clover)