### PR TITLE
Add outdoor 3D planning to aerial robotic landscape

### DIFF
--- a/3d_planning_outdoor.md
+++ b/3d_planning_outdoor.md
@@ -1,0 +1,38 @@
+# Outdoor 3D Planning
+
+This page is a central landing page for outdoor 3D planning in aerial robotics. 
+
+## Development Kanban Board
+
+Developers in the ROS Aerial Working Group keep track of their work for outdoor 3D planning [in a Kanban board.](https://github.com/orgs/ROS-Aerial/projects/1/views/2).
+
+## Goals
+
+* Create open source algorithms for planning and navigation in outdoor 3D environments
+* Add plugins for ROS-based planners to communicate with common autopilots including PX4 and ArduPilot
+* Create visualization tooling for viewing 3D plans in outdoor environments
+* Create simulations of vehicles in order to demonstrate and test features
+* Support intuitive ROS 2 interfaces to many components
+* Demonstrate capabilities on physical hardware by performing flight tests and demonstrations
+
+## Repositories
+
+The following are a list of repositories closely related to outdoor 3D planning.
+
+* [grid_map_geo](https://github.com/ethz-asl/grid_map_geo)
+* [terrain-navigation](https://github.com/ethz-asl/terrain-navigation)
+
+## How to get involved?
+
+* Request to work on issues in the Kanban board
+* Help test pull requests in simulation or on hardware
+* Join the [Outdoor 3D planning Discord thread](https://discord.com/channels/1077825543698927656/1166423176893440031)
+
+## Members
+
+[comment]: <> (Keep sorted alphabetically please)
+
+* [botmayank](https://github.com/botmayank)
+* [Jaeyoung-Lim](https://github.com/jaeyoung-lim)
+* [ryanf55](https://github.com/ryanf55)
+* [srmainwaring](https://github.com/srmainwaring)

--- a/3d_planning_outdoor.md
+++ b/3d_planning_outdoor.md
@@ -27,8 +27,11 @@ The following are a list of repositories closely related to outdoor 3D planning.
 * Request to work on issues in the Kanban board
 * Help test pull requests in simulation or on hardware
 * Join the [Outdoor 3D planning Discord thread](https://discord.com/channels/1077825543698927656/1166423176893440031)
+* Submit your first pull request to add yourself to the member list below
 
 ## Members
+
+The following members have been active contributors in the past year. The list may not be comprehensive.
 
 [comment]: <> (Keep sorted alphabetically please)
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The following list has been compiled during the startup meeting of this workgrou
 * Legality and airspace access
 * [Hardware, Components, and Dev Kits](hardware.md)
 * [Aerial Vehicle Types](aerial_vehicles.md)
-* Planning in 3D
+* [Outdoor Planning in 3D](3d_planning_outdoor.md)
+* Indoor Planning in 3D
 * [Middleware and Drivers](middleware_and_drivers.md)
 


### PR DESCRIPTION
Add a landing page for the outdoor 3D planning work. 

Before merge, please ensure I have approval from the following members that they would like to be included in the list.
* @Jaeyoung-Lim 
* @botmayank 
* @srmainwaring 

If you would not like to be included, please share and I will remove you. This is in no way a commitment; I'm more just trying to give credit where credit is due to the amazing contributors of this FOSS.