### PR TITLE
Add drone core 2 as a carrier board in hardware list

### DIFF
--- a/hardware.md
+++ b/hardware.md
@@ -69,6 +69,7 @@ Several vendors have developed carrier boards which can expose input/output port
 - [Mistral MRD5165 Eagle based on Qualcomm RB5](https://www.mistralsolutions.com/mrd5165-eagle-kit/)
 - [ARK Electronics Jetson PAB carrier](https://arkelectron.com/product/ark-jetson-pab-carrier/)
 - [Dronee Lychee Drone autopilot hardware](https://dronee.aero/pages/lychee)
+- [Airvolute DroneCore2 Jetson + Cube](https://airvolute.com/dronecore-2/)
 
 ### Reference Bill of Materials
 


### PR DESCRIPTION
Adds Airvolute's DroneCore2 carrier board to the list of hardware carrier boards. It looks like a really cool board with CubeOrange + Jetson support.

https://ardupilot.org/copter/docs/common-airvolute-DroneCore-Suite.html
https://airvolute.com/dronecore-2/