### PR TITLE
Add ardupilot ros2 repo to indoor nav package list

### DIFF
--- a/docs/aerial_autonomy_stacks.md
+++ b/docs/aerial_autonomy_stacks.md
@@ -91,4 +91,5 @@ Given the above [Aerial Autonomy Stacks](https://github.com/ROS-Aerial/aerial_ro
 | [tum_ardrone](https://github.com/tum-vision/tum_ardrone)  | ✓     | Mono camera     | ROS 1 | N/A | AR.Drone | 05/2014 |
 | [kr_autonomous_flight](https://github.com/KumarRobotics/kr_autonomous_flight)   | ✓    | Stereo camera/LiDAR/IMU | ROS 1 | Gazebo | Pixhawk | 08/2023 |
 | [px4_sim_ros2](https://github.com/ParsaKhaledi/px4_sim_ros2)   | ✓    | Stereo camera | ROS 2 | Gazebo | PX4 | 04/2024 |
+| [ardupilot_ros](https://github.com/ArduPilot/ardupilot_ros/tree/humble)   | ✓    | LiDAR | ROS 2 | Gazebo | Ardupilot | 02/2024 |
 


### PR DESCRIPTION
Adds the Ardupilot ROS2 indoor nav GSOC work from @snktshrma @Ryanf55 to the list of indoor nav packages.

https://discuss.ardupilot.org/t/gsoc-2022-wrapping-up-update-ros-integration-for-non-gps-navigation-and-off-board-path-planning/90701
