### PR TITLE
add useful vi/vo datasets to the aerial autonomy VIO package information

### DIFF
--- a/docs/aerial_autonomy_stacks.md
+++ b/docs/aerial_autonomy_stacks.md
@@ -57,6 +57,7 @@ Here is a list of VIO packages that people can use if they have a [depth camera]
 - [Kaggle Underwater forward-looking VI dataset](https://www.kaggle.com/datasets/viseaonlab/flsea-vi)
 - [The Air Lab Datasets](https://theairlab.org/datasets/)
 - [VICON ROS2 bag file Google drive](https://drive.google.com/drive/folders/1xQ1KcZhZ5pioPXTyrZBN6Mjxkfpcd_B3)
+- [The UZH FPV Dataset](https://fpv.ifi.uzh.ch/datasets/)
 
 ## Working list autonomy stacks
 

--- a/docs/aerial_autonomy_stacks.md
+++ b/docs/aerial_autonomy_stacks.md
@@ -51,6 +51,13 @@ Here is a list of VIO packages that people can use if they have a [depth camera]
 - [SLAMcore](https://www.slamcore.com/product/) stand alone SDK
 - [ORB-SLAM3 ROS2](https://github.com/suchetanrs/ORB-SLAM3-ROS2-Docker)
 
+### Visual Odometry Datasets
+
+- [Kaggle Zurich Urban Micro Aerial Vehicle](https://www.kaggle.com/datasets/mrisdal/zurich-urban-micro-aerial-vehicle)
+- [Kaggle Underwater forward-looking VI dataset](https://www.kaggle.com/datasets/viseaonlab/flsea-vi)
+- [The Air Lab Datasets](https://theairlab.org/datasets/)
+- [VICON ROS2 bag file Google drive](https://drive.google.com/drive/folders/1xQ1KcZhZ5pioPXTyrZBN6Mjxkfpcd_B3)
+
 ## Working list autonomy stacks
 
 This is just a list of autonomy stacks with links, such that later we can add them to the overview.


### PR DESCRIPTION
Add useful dataset links for visual (inertial) odometry testing. Some datasets target aerial vehicles but others different platforms. Datasets come in different formats with exception to the google drive link which should purely be ros2 bag files for ease of use.  