### PR TITLE
Updating Crazyflie autopilot suite info

### DIFF
--- a/docs/aerial_vehicles.md
+++ b/docs/aerial_vehicles.md
@@ -49,5 +49,6 @@ Each autopilot suite have their a wide range of supported vehicles, to which thi
 * [Ardupilot supported vehicle types](https://ardupilot.org/ardupilot/docs/common-all-vehicle-types.html)
 * [Paparazzi](https://wiki.paparazziuav.org/wiki/Airframes)
 * [PX4](https://docs.px4.io/master/en/airframes/airframe_reference.html)
+* [Crazyflie](https://www.bitcraze.io/documentation/repository/crazyflie-firmware/master/#the-crazyflie-2x-family)
 
 --8<-- "docs/goatcounter.html"

--- a/docs/autopilots_suites.md
+++ b/docs/autopilots_suites.md
@@ -6,7 +6,7 @@ There are several autopilot suites available for control-boards for aerial vehic
 |---| --- | --- | --- | --- | --- |
 | [Ardupilot](https://ardupilot.org/) ([GitHub](https://github.com/ArduPilot/ardupilot)) | 2009 | 4.5.2 (05/24) |  GPL 3.0 | yes | Copters, Fixed wings, VTOL |
 | [Betaflight](https://betaflight.com/) ([GitHub](https://github.com/betaflight/betaflight)) | 2015 | 4.5.0 (04/24) |  GPL 3.0 | no  | Copters |
-| [crazyflie-firmware](https://www.bitcraze.io/) ([GitHub](https://github.com/bitcraze/crazyflie-firmware))  | 2011 | 2023.11 |  GPL 3.0 | yes* | Quadcopters |
+| [crazyflie-firmware](https://www.bitcraze.io/) ([GitHub](https://github.com/bitcraze/crazyflie-firmware))  | 2011 | 2024.2 |  GPL 3.0 | yes* | Quadcopters, Flapping wings |
 |  [DJI autopilot](https://developer.dji.com/) ([GitHub](https://github.com/dji-sdk/Onboard-SDK-ROS)) | 2006 | 2023.9 | closed | yes |  Copters, VTOLS |
 | [Paparazzi](https://wiki.paparazziuav.org/wiki/Main_Page) ([GitHub](https://github.com/paparazzi/paparazzi))   | 2003 | 6.3.0 (12/23)  | GPL 2.0 | no | Copters, Fixed wings, VTOL |
 | [PX4](https://px4.io/) ([GitHub](https://github.com/PX4/PX4-Autopilot)) | 2009 | 1.14.0 (10/23)  |BSD 3-Clause | yes | Copters, Fixed wings, VTOL |'


### PR DESCRIPTION
Updating information about the Crazyflie autopilot suite
- listing the suite in Aerial Vehicles
- updating version number and supported vehicles in Autopilot Suites