### PR TITLE
Github Actions: Adding LinkChecker and installation from requirements.txt into Workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,11 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: 3.x
-      - run: pip install mkdocs pymdown-extensions mkdocs-git-revision-date-localized-plugin
+      - name: Installing dependencies
+        run: pip install -r requirements.txt
       - run: git config user.name 'github-actions[bot]' && git config user.email 'github-actions[bot]@users.noreply.github.com'
-      - run: mkdocs gh-deploy --force
+      - name: Build and Deployment
+        run: mkdocs gh-deploy --force
+      - name: Checking Links
+        run: mkdocs-linkcheck --sync -r docs/ -m get --verbose
+        continue-on-error: true 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+mkdocs~=1.6.1
+pymdown-extensions~=10.12
+mkdocs-git-revision-date-localized-plugin~=1.3.0
+mkdocs-linkcheck~=1.0.6
+requests~=2.32.3


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/f80c344b-ccac-42e6-8123-0b67c4aa8f03)



I've done some modifications to the GitHub Actions workflow and added a `requirements.txt` file. For now, we can see all the links as they are being checked and a final summary.  

I would like to mention that some of these sites are not reporting back the expected result but if you go there directly, they are working fine. In the meantime, I asked to GitHub Actions to skip the exit code for this particular step, and leave it to manual inspection.  
