### PR TITLE
build.yml: Fix for Github actions fetch depth to stop messing with the timedate

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v2
         with:
           python-version: 3.x


### PR DESCRIPTION
Fix was found at `git-revision-date-localized` plugin documentation.

From https://github.com/timvink/mkdocs-git-revision-date-localized-plugin?tab=readme-ov-file#note-when-using-build-systems-like-github-actions : 

> This plugin needs access to the last commit that touched a specific file to be able to retrieve the date. By default many CI/CD build systems only retrieve the last commit, which means you might need to change your CI/CD settings:

>    Github Actions: set fetch-depth to 0