### PR TITLE
Update aerial_autonomy_stacks.md

### DIFF
--- a/docs/aerial_autonomy_stacks.md
+++ b/docs/aerial_autonomy_stacks.md
@@ -16,7 +16,7 @@ the following autonomy stack table was extracted and adapted.
 | -------------- | ----- | ------- |
 | [Aerostack(1)](https://github.com/cvar-upm/aerostack/wiki)       | ROS        | 11/2021 |
 | [Aerostack2](https://github.com/aerostack2/aerostack2)       | ROS 2      | 07/2025 | 
-| [`aerial-autonomy-stack`](https://github.com/JacopoPan/aerial-autonomy-stack)       | ROS 2        | 08/2025      | 
+| [Aerial autonomy stack (AAS)](https://github.com/JacopoPan/aerial-autonomy-stack)       | ROS 2        | 08/2025      | 
 | [Agilicious](https://agilicious.readthedocs.io/en/latest/index.html)       | ROS        | 03/2023      | 
 | [KumarRobotics Autonomy Stack](https://github.com/KumarRobotics/kr_autonomous_flight)  | ROS        | 08/2023 |
 | [CrazyChoir](https://github.com/OPT4SMART/crazychoir)     | ROS 2      | 06/2025 |

--- a/docs/aerial_autonomy_stacks.md
+++ b/docs/aerial_autonomy_stacks.md
@@ -16,6 +16,7 @@ the following autonomy stack table was extracted and adapted.
 | -------------- | ----- | ------- |
 | [Aerostack(1)](https://github.com/cvar-upm/aerostack/wiki)       | ROS        | 11/2021 |
 | [Aerostack2](https://github.com/aerostack2/aerostack2)       | ROS 2      | 07/2025 | 
+| [`aerial-autonomy-stack`](https://github.com/JacopoPan/aerial-autonomy-stack)       | ROS 2        | 08/2025      | 
 | [Agilicious](https://agilicious.readthedocs.io/en/latest/index.html)       | ROS        | 03/2023      | 
 | [KumarRobotics Autonomy Stack](https://github.com/KumarRobotics/kr_autonomous_flight)  | ROS        | 08/2023 |
 | [CrazyChoir](https://github.com/OPT4SMART/crazychoir)     | ROS 2      | 06/2025 |


### PR DESCRIPTION
Hello maintainers, 

I understand that the table shouldn't be edited directly (because it's updated by  [`.github/workflows/update-dates.yaml`](https://github.com/ROS-Aerial/aerial_robotic_landscape/blob/main/.github/workflows/update-dates.yaml)) but, if possible, I'd like to add some of the work I've done to have a ros2, action-based, common interface to px4 and ardupilot with yolov8